### PR TITLE
Use tonic-build compile_fds to build file descriptor set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,13 +995,14 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4ee8877250136bd7e3d2331632810a4df4ea5e004656990d8d66d2f5ee8a67"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
+ "prost-types",
  "quote",
  "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -37,15 +37,9 @@ Usage with [`tonic-build`](https://crates.io/crates/tonic-build):
 ```rust
 let file_descriptors = protox::compile(["root.proto"], ["."]).unwrap();
 
-let file_descriptor_path = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"))
-    .join("file_descriptor_set.bin");
-fs::write(&file_descriptor_path, file_descriptors.encode_to_vec()).unwrap();
-
 tonic_build::configure()
     .build_server(true)
-    .file_descriptor_set_path(&file_descriptor_path)
-    .skip_protoc_run()
-    .compile(&["root.proto"], &["."])
+    .compile_fds(file_descriptors)
     .unwrap();
 ```
 

--- a/protox/Cargo.toml
+++ b/protox/Cargo.toml
@@ -59,7 +59,7 @@ serde_yaml = "0.9.34"
 similar-asserts = { version = "1.2.0" }
 tempfile = "3.10.1"
 serde_json = "1.0.117"
-tonic-build = "0.12.0"
+tonic-build = "0.12.3"
 
 [package.metadata.release]
 tag-name = "{{version}}"

--- a/protox/src/lib.rs
+++ b/protox/src/lib.rs
@@ -30,15 +30,9 @@
 //!
 //! let file_descriptors = protox::compile(["root.proto"], ["."]).unwrap();
 //!
-//! let file_descriptor_path = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"))
-//!     .join("file_descriptor_set.bin");
-//! fs::write(&file_descriptor_path, file_descriptors.encode_to_vec()).unwrap();
-//!
 //! tonic_build::configure()
 //!     .build_server(true)
-//!     .file_descriptor_set_path(&file_descriptor_path)
-//!     .skip_protoc_run()
-//!     .compile(&["root.proto"], &["."])
+//!     .compile_fds(file_descriptors)
 //!     .unwrap();
 //! ```
 //!


### PR DESCRIPTION
Updates the example of usage with `tonic-build`.